### PR TITLE
Fix code scanning alert no. 2: Unsafe jQuery plugin

### DIFF
--- a/assets/js/plugins/jquery.magnific-popup.js
+++ b/assets/js/plugins/jquery.magnific-popup.js
@@ -347,7 +347,14 @@ MagnificPopup.prototype = {
 		$('html').css(windowStyles);
 
 		// add everything to DOM
-		mfp.bgOverlay.add(mfp.wrap).prependTo( mfp.st.prependTo || _body );
+		var prependTarget = _body;
+		if (mfp.st.prependTo) {
+			prependTarget = $(document).find(mfp.st.prependTo);
+			if (prependTarget.length === 0) {
+				prependTarget = _body;
+			}
+		}
+		mfp.bgOverlay.add(mfp.wrap).prependTo(prependTarget);
 
 		// Save last focused element
 		mfp._lastFocusedEl = document.activeElement;


### PR DESCRIPTION
Fixes [https://github.com/paraskevasleivadaros/paraskevasleivadaros.github.io/security/code-scanning/2](https://github.com/paraskevasleivadaros/paraskevasleivadaros.github.io/security/code-scanning/2)

To fix the problem, we need to ensure that the `prependTo` option is sanitized before it is used in the jQuery method. This can be done by validating that `prependTo` is a valid CSS selector and not an HTML string. We can use jQuery's `find` method to ensure it is treated as a selector.

1. Modify the code to sanitize the `prependTo` option before it is used.
2. Ensure that the `prependTo` option is always treated as a CSS selector by using jQuery's `find` method.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
