### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/scrape_talks.yml
+++ b/.github/workflows/scrape_talks.yml
@@ -6,6 +6,9 @@ on:
       - 'talks/**'
       - 'talkmap.ipynb'
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/paraskevasleivadaros/paraskevasleivadaros.github.io/security/code-scanning/5](https://github.com/paraskevasleivadaros/paraskevasleivadaros.github.io/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the permissions required for the workflow. Since the workflow includes a `git push` step, it requires `contents: write` permissions. All other permissions will be omitted unless explicitly needed, ensuring the workflow operates with the minimum necessary privileges.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
